### PR TITLE
Added build all

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,159 +1,184 @@
 {
-    "name": "pulsoid-electron",
-    "version": "1.0.0",
-    "author": {
-        "name": "NekoSuneVR",
-        "email": "nekosunevr@hyperiontv.net"
+  "name": "pulsoid-electron",
+  "homepage": "https://github.com/NekoSuneProjects/pulsoid-electron-app",
+  "version": "1.0.0",
+  "author": {
+    "name": "NekoSuneVR",
+    "email": "nekosunevr@hyperiontv.net"
+  },
+  "license": "MIT",
+  "description": "PulsoidApp is Program use Pulsoid With Discord RPC and Dashboard on App with Overlay can use on OBS",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder",
+    "build:win": "electron-builder --win",
+    "build:mac": "electron-builder --mac",
+    "build:linux:x64": "electron-builder --linux --x64",
+    "build:linux:arm64": "electron-builder --linux --arm64",
+    "build:linux:armv7l": "electron-builder --linux --armv7l",
+    "build:linux:all": "npm run build:linux:x64 && npm run build:linux:arm64 && npm run build:linux:armv7l",
+    "build:snap:x64": "electron-builder --linux snap --x64",
+    "build:snap:arm64": "electron-builder --linux snap --arm64",
+    "build:snap:armv7l": "electron-builder --linux snap --armv7l",
+    "build:snap:all": "npm run build:snap:x64 && npm run build:snap:arm64 && npm run build:snap:armv7l"
+  },
+  "build": {
+    "copyright": "Copyright © 2024-2025 NekoSuneVR",
+    "appId": "com.nekosunevr.pulsoidapp",
+    "productName": "PulsoidApp",
+    "asar": true,
+    "files": [
+      "!node_modules/.cache",
+      "!dist/**"
+    ],
+    "appx": {
+      "backgroundColor": "#ffffff",
+      "displayName": "PulsoidApp",
+      "publisher": "CN=NekoSuneVR",
+      "publisherDisplayName": "NekoSuneVR",
+      "identityName": "com.nekosunevr.pulsoidapp"
     },
-    "license": "MIT",
-    "description": "PulsoidApp is Program use Pulsoid With Discord RPC and Dashboard on App with Overlay can use on OBS",
-    "main": "main.js",
-    "scripts": {
-        "start": "electron .",
-        "build": "electron-builder",
-        "build:win": "electron-builder --win",
-        "build:mac": "electron-builder --mac",
-        "build:linux": "electron-builder --linux --x64",
-        "build:pi": "electron-builder --linux --armv7l --arm64",
-        "build:snap": "electron-builder --linux snap"
+    "directories": {
+      "output": "dist/${os}-${arch}",
+      "buildResources": "assets"
     },
-    "build": {
-        "copyright": "Copyright © 2024-2025 NekoSuneVR",
-        "appId": "com.nekosunevr.pulsoidapp",
-        "productName": "PulsoidApp",
-        "asar": true,
-        "appx": {
-            "backgroundColor": "#ffffff",
-            "displayName": "PulsoidApp",
-            "publisher": "CN=NekoSuneVR",
-            "publisherDisplayName": "NekoSuneVR",
-            "identityName": "com.nekosunevr.pulsoidapp"
+    "win": {
+      "artifactName": "${productName}-Setup-${version}.${ext}",
+      "target": [
+        "nsis",
+        "msi"
+      ],
+      "icon": "assets/icon.ico",
+      "files": [
+        "main.js",
+        "preload.js",
+        "LICENSE",
+        "README.md",
+        "CHANGELOG.md",
+        "assets/**/*",
+        "src/**/*",
+        "package.json",
+        "node_modules/**/*"
+      ]
+    },
+    "mac": {
+      "artifactName": "${productName}-Setup-${version}.${ext}",
+      "target": [
+        "dmg",
+        "zip"
+      ],
+      "category": "public.app-category.healthcare-fitness",
+      "icon": "assets/icon.icns",
+      "files": [
+        "main.js",
+        "preload.js",
+        "LICENSE",
+        "README.md",
+        "CHANGELOG.md",
+        "assets/**/*",
+        "src/**/*",
+        "package.json",
+        "node_modules/**/*"
+      ]
+    },
+    "linux": {
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "category": "Utility",
+      "maintainer": "NekoSuneVR",
+      "icon": "assets/icon.png",
+      "synopsis": "Pulsoid with Discord RPC and overlay dashboard",
+      "description": "PulsoidApp brings Pulsoid with Discord Rich Presence and an in-app dashboard with an OBS-friendly overlay.",
+      "files": [
+        "main.js",
+        "preload.js",
+        "LICENSE",
+        "README.md",
+        "CHANGELOG.md",
+        "assets/**/*",
+        "src/**/*",
+        "package.json",
+        "node_modules/**/*"
+      ],
+      "target": [
+        {
+          "target": "deb",
+          "arch": "x64"
         },
-        "directories": {
-            "output": "dist",
-            "buildResources": "assets"
+        {
+          "target": "deb",
+          "arch": "arm64"
         },
-        "files": [
-            "**/*",
-            "!node_modules/.cache"
-        ],
-        "win": {
-            "artifactName": "${productName}-Setup-${version}.${ext}",
-            "target": [
-                "nsis",
-                "msi"
-            ],
-            "icon": "assets/icon.ico",
-            "files": [
-                "main.js",
-                "preload.js",
-                "LICENSE",
-                "README.md",
-                "CHANGELOG.md",
-                "assets/**/*",
-                "src/**/*",
-                "package.json",
-                "node_modules/**/*"
-            ]
+        {
+          "target": "deb",
+          "arch": "armv7l"
         },
-        "mac": {
-            "artifactName": "${productName}-Setup-${version}.${ext}",
-            "target": [
-                "dmg",
-                "zip"
-            ],
-            "category": "public.app-category.healthcare-fitness",
-            "icon": "assets/icon.icns",
-            "files": [
-                "main.js",
-                "preload.js",
-                "LICENSE",
-                "README.md",
-                "CHANGELOG.md",
-                "assets/**/*",
-                "src/**/*",
-                "package.json",
-                "node_modules/**/*"
-            ]
+        {
+          "target": "snap",
+          "arch": "x64"
         },
-        "linux": {
-            "artifactName": "${productName}-${version}.${ext}",
-            "category": "Utility",
-            "maintainer": "NekoSuneVR",
-            "icon": "assets/icon.png",
-            "synopsis": "Pulsoid with Discord RPC and overlay dashboard",
-            "description": "PulsoidApp brings Pulsoid with Discord Rich Presence and an in-app dashboard with an OBS-friendly overlay.",
-            "files": [
-                "main.js",
-                "preload.js",
-                "LICENSE",
-                "README.md",
-                "CHANGELOG.md",
-                "assets/**/*",
-                "src/**/*",
-                "package.json",
-                "node_modules/**/*"
-            ],
-            "target": [
-                {
-                  "target": "deb",
-                  "arch": ["armv7l", "arm64", "x64"]
-                },
-                {
-                  "target": "AppImage",
-                  "arch": ["armv7l", "arm64", "x64"]
-                },
-                "snap"
-            ]
+        {
+          "target": "snap",
+          "arch": "arm64"
         },
-        "snap": {
-            "confinement": "strict",
-            "grade": "stable",
-            "summary": "PulsoidApp integrates Pulsoid with Discord RPC, a dashboard app for OBS.",
-            "description": "PulsoidApp is used with Pulsoid, offering OBS overlays, Discord RPC integration, and easy usage within a single application.",
-            "plugs": [
-                "network",
-                "x11",
-                "wayland",
-                "unity7",
-                "pulseaudio",
-                "home",
-                "process-control",
-                "system-observe",
-                "desktop",
-                "desktop-legacy"
-            ],
-            "environment": {
-                "DISCORD_RPC_ENABLE": "1",
-                "ELECTRON_DISABLE_SECURITY_WARNINGS": "1"
-            }
-        },
-        "deb": {
-            "priority": "optional",
-            "depends": [
-                "libgtk-3-0",
-                "libnss3",
-                "libxss1",
-                "libasound2",
-                "libatk-bridge2.0-0",
-                "libdrm2",
-                "libgbm1"
-            ]
+        {
+          "target": "snap",
+          "arch": "armv7l"
         }
+      ]
     },
-
-    "nsis": {
-        "allowToChangeInstallationDirectory": true,
-        "license": "LICENSE",
-        "oneClick": false
+    "snap": {
+      "useTemplateApp": false,
+      "confinement": "strict",
+      "grade": "stable",
+      "summary": "PulsoidApp integrates Pulsoid with Discord RPC, a dashboard app for OBS.",
+      "description": "PulsoidApp is used with Pulsoid, offering OBS overlays, Discord RPC integration, and easy usage within a single application.",
+      "environment": {
+        "LD_LIBRARY_PATH": "$SNAP/usr/lib:$SNAP/usr/local/lib",
+        "DISCORD_RPC_ENABLE": "1",
+        "ELECTRON_DISABLE_SECURITY_WARNINGS": "1"
+      },
+      "plugs": [
+        "network",
+        "x11",
+        "wayland",
+        "unity7",
+        "pulseaudio",
+        "home",
+        "process-control",
+        "system-observe",
+        "desktop",
+        "desktop-legacy"
+      ]
     },
-    "dependencies": {
-        "discord-rpc": "^4.0.1",
-        "electron-store": "^7.0.3",
-        "ws": "^8.18.0"
-    },
-    "devDependencies": {
-        "electron": "^30.0.0",
-        "electron-builder": "^25.1.8"
-    }
+    "deb": {
+    "category": "Utility",
+      "fpm": [
+        "--deb-no-default-config-files"
+      ],
+    "depends": [
+      "libgtk-3-0",
+      "libnss3",
+      "libxss1",
+      "libasound2",
+      "libatk-bridge2.0-0",
+      "libdrm2",
+      "libgbm1"
+    ]
+   }
+  },
+  "nsis": {
+    "allowToChangeInstallationDirectory": true,
+    "license": "LICENSE",
+    "oneClick": false
+  },
+  "dependencies": {
+    "discord-rpc": "^4.0.1",
+    "electron-store": "^7.0.3",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "electron": "^30.0.0",
+    "electron-builder": "^25.1.8"
+  }
 }


### PR DESCRIPTION
switch build command with "npm run build:linux:all" as it builds all architectures in individual folders, not overwriting changes and completely seperates concerns. you may be able to get away with running each command individually as it runs each one one by one in that command, and makes snaps for them :3